### PR TITLE
Support multiple line stdin

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 
 const _  = require('ramda');
 const fs = require('fs');
-const buffer = require('buffer);
+const buffer = require('buffer');
 
 const validOpts = opts => {
   if(!opts || !opts.commands) return true;

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 
 const _  = require('ramda');
 const fs = require('fs');
-
+const buffer = require('buffer);
 
 const validOpts = opts => {
   if(!opts || !opts.commands) return true;
@@ -19,22 +19,23 @@ module.exports.load = opts => {
   if(!validOpts(opts)) return false;
   if (process.stdin.isTTY) return false;
   
-  const BUFSIZE = 65536;
+  const BUFSIZE = buffer.kMaxLength;
   let nbytes = 0;
   let chunks = [];
-  let buffer = '';
+  let buf = '';
 
   while(true) {
     try {
-      buffer = Buffer.alloc(BUFSIZE);
-      nbytes = fs.readSync(0, buffer, 0, BUFSIZE, null);
+      buf = Buffer.alloc(BUFSIZE);
+      nbytes = fs.readSync(0, buf, 0, BUFSIZE, null);
     } 
     catch (e) {
+      if (e.code == 'EOF') break
       if (e.code != 'EAGAIN') throw e; 
     };
 
     if (nbytes === 0) break;
-     chunks.push(buffer.slice(0, nbytes));
+     chunks.push(buf.slice(0, nbytes));
   };
   
   const stdin = Buffer.concat(chunks).toString();


### PR DESCRIPTION
I want to receive multiple line input from pipe in nodejs command.
I found currently this library does not support multiple line, example: `cat foo.txt | yargs-cli.js`.

So I'm trying to change some lines, Then I got works well.
Could you support multiple line stdin?